### PR TITLE
Update to Jet 0.7.27

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : jet
-version    : 0.5.25
-release    : 4
+version    : 0.7.27
+release    : 5
 source     :
-    - https://github.com/borkdude/jet/archive/refs/tags/v0.5.25.tar.gz : 9054dfd4406c4fb034c68eddda0996ca238345bd97695e579a7c0fdeeb639ab0
+    - https://github.com/borkdude/jet/archive/refs/tags/v0.7.27.tar.gz : 3e473b00acd80c2caf3eeb314b7d5db4c8553d301354d0647a68c8a5082ed8d2
 license    : EPL-1.0
 networking : yes
 component  : programming.tools

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -23,9 +23,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2023-05-22</Date>
-            <Version>0.5.25</Version>
+        <Update release="5">
+            <Date>2023-08-14</Date>
+            <Version>0.7.27</Version>
             <Comment>Packaging update</Comment>
             <Name>Oliver Marks</Name>
             <Email>oly@digitaloctave.com</Email>


### PR DESCRIPTION
### Summary

Updates to version 0.7.27. Changes can be found [here](https://raw.githubusercontent.com/borkdude/jet/v0.7.27/CHANGELOG.md).

### Test Plan

Ran jet --version to check latest version was returned

### Checklist

- [x] Package was built and tested against unstable
